### PR TITLE
feat(p1): Railway ErrorKind badge + AiError label on failure nodes

### DIFF
--- a/src/AgentScope.Web/Components/Pages/Prompts.razor
+++ b/src/AgentScope.Web/Components/Pages/Prompts.razor
@@ -11,7 +11,7 @@
 
 <!-- App selector -->
 <MudPaper Class="pa-4 mb-4" Elevation="0" Style="border:1px solid #313244; border-radius:12px;">
-    <MudGrid Spacing="2" AlignItems="Center">
+    <MudGrid Spacing="2" Style="align-items:center;">
         <MudItem xs="12" sm="6">
             <MudSelect T="Guid?" Label="Application" @bind-Value="_selectedAppId" @bind-Value:after="LoadPrompts"
                        Clearable="true" Dense="true" Variant="Variant.Outlined" AnchorOrigin="Origin.BottomLeft">
@@ -97,7 +97,7 @@ else
 }
 
 <!-- Create Dialog -->
-<MudDialog @bind-IsVisible="_showCreate" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
+<MudDialog @bind-Visible="_showCreate" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
     <TitleContent><MudText Typo="Typo.h6">New Prompt</MudText></TitleContent>
     <DialogContent>
         <MudTextField @bind-Value="_newSlug" Label="Slug" Placeholder="e.g. system-prompt"
@@ -120,7 +120,7 @@ else
 </MudDialog>
 
 <!-- Publish New Version Dialog -->
-<MudDialog @bind-IsVisible="_showPublish" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
+<MudDialog @bind-Visible="_showPublish" Options="@(new DialogOptions { MaxWidth = MaxWidth.Medium, FullWidth = true })">
     <TitleContent><MudText Typo="Typo.h6">Publish New Version — <span style="color:#89B4FA;">@_editingSlug</span></MudText></TitleContent>
     <DialogContent>
         <MudTextField @bind-Value="_newContent" Label="Content" Lines="12"
@@ -140,7 +140,7 @@ else
 </MudDialog>
 
 <!-- History Dialog -->
-<MudDialog @bind-IsVisible="_showHistory" Options="@(new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true })">
+<MudDialog @bind-Visible="_showHistory" Options="@(new DialogOptions { MaxWidth = MaxWidth.Large, FullWidth = true })">
     <TitleContent><MudText Typo="Typo.h6">Version History — <span style="color:#89B4FA;">@_editingSlug</span></MudText></TitleContent>
     <DialogContent>
         @if (_history.Count == 0)

--- a/src/AgentScope.Web/Components/Pages/TraceDetail.razor
+++ b/src/AgentScope.Web/Components/Pages/TraceDetail.razor
@@ -106,7 +106,7 @@ else
         <MudPaper Elevation="0" Class="mb-6 pa-4"
                   Style="border:1px solid #1F2937; border-radius:12px; background:#0A0E1A;">
             <div style="font-size:.72rem; color:#6B7280; margin-bottom:12px; letter-spacing:.05em; text-transform:uppercase;">
-                Bind / Map / Then chain — green = Success · red = Failure
+                Bind / Map / Then chain — green = Success · red = Failure · <span style="color:#F59E0B; text-transform:none;">amber</span> = Monadic · red badge = Exception
             </div>
             @foreach (var root in _railwayRoots)
             {
@@ -215,6 +215,14 @@ else
                 @if (isFailure)
                 {
                     <span style="font-size:.7rem; color:#EF4444;">✗ Failure</span>
+                    @if (node.ErrorKind is not null)
+                    {
+                        var kindColor = node.ErrorKind == "Monadic" ? "#F59E0B" : "#EF4444";
+                        var kindBg    = node.ErrorKind == "Monadic" ? "rgba(245,158,11,0.15)" : "rgba(239,68,68,0.15)";
+                        <span style="@($"font-size:.65rem; padding:1px 6px; border-radius:3px; background:{kindBg}; color:{kindColor}; font-family:'JetBrains Mono',monospace; font-weight:600; letter-spacing:.03em;")">
+                            @node.ErrorKind
+                        </span>
+                    }
                 }
                 @if (!string.IsNullOrEmpty(node.ErrorCode))
                 {
@@ -224,7 +232,9 @@ else
             </div>
             @if (!string.IsNullOrEmpty(node.StatusMessage) && isFailure)
             {
-                <div style="font-size:.72rem; color:#9CA3AF; margin-top:3px; font-style:italic;">@node.StatusMessage</div>
+                <div style="font-size:.72rem; color:#F87171; margin-top:3px; font-family:'JetBrains Mono',monospace;">
+                    <span style="margin-right:4px;">&#9888;</span>@node.StatusMessage
+                </div>
             }
         </div>
 

--- a/src/AgentScope.Web/Services/DashboardService.cs
+++ b/src/AgentScope.Web/Services/DashboardService.cs
@@ -15,6 +15,7 @@ public sealed record RailwayNode(
     bool?      IsSuccess,
     string?    ErrorCode,
     string?    StatusMessage,
+    string?    ErrorKind,        // "Monadic" | "Exception" | null
     long       DurationMs,
     SpanStatus Status,
     List<RailwayNode> Children);
@@ -189,16 +190,19 @@ public sealed class DashboardService
         var nodeMap = spans.ToDictionary(
             s => s.SpanId,
             s => new RailwayNode(
-                SpanId:       s.SpanId,
-                ParentSpanId: s.ParentSpanId,
-                Name:         s.Name,
-                Operation:    s.RailwayOp?.ToString(),
-                IsSuccess:    s.ResultIsSuccess,
-                ErrorCode:    s.RailwayErrorCode,
+                SpanId:        s.SpanId,
+                ParentSpanId:  s.ParentSpanId,
+                Name:          s.Name,
+                Operation:     s.RailwayOp?.ToString(),
+                IsSuccess:     s.ResultIsSuccess,
+                ErrorCode:     s.RailwayErrorCode,
                 StatusMessage: s.StatusMessage,
-                DurationMs:   s.DurationMs,
-                Status:       s.Status,
-                Children:     []));
+                ErrorKind:     s.ResultIsSuccess == false && s.StatusMessage is not null
+                                   ? Classify(s.StatusMessage).Kind
+                                   : null,
+                DurationMs:    s.DurationMs,
+                Status:        s.Status,
+                Children:      []));
 
         var roots = new List<RailwayNode>();
         foreach (var node in nodeMap.Values)


### PR DESCRIPTION
## Summary
- `RailwayNode` record: nuovo campo `ErrorKind` (`Monadic` | `Exception` | `null`)
- `GetRailwayGraphAsync`: calcola `ErrorKind` via `Classify()` esistente
- TraceDetail.razor: badge amber/red dopo `✗ Failure` con colore semantico
- TraceDetail.razor: StatusMessage su nodi failure → rosso monospace + icona ⚠
- Legenda Railway Flow aggiornata con color coding

Closes #1

## Test plan
- [ ] Build verde ARM64 ✅
- [ ] Trace con failure Monadic → badge amber "Monadic"
- [ ] Trace con failure Exception → badge rosso "Exception"
- [ ] StatusMessage visibile in rosso con ⚠

🤖 Generated with [Claude Code](https://claude.com/claude-code)