### PR TITLE
feat(p2): Redis sliding-window rate limiting middleware

### DIFF
--- a/src/AgentScope.Api/Middleware/RateLimitMiddleware.cs
+++ b/src/AgentScope.Api/Middleware/RateLimitMiddleware.cs
@@ -1,0 +1,163 @@
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace AgentScope.Api.Middleware;
+
+/// <summary>
+/// Redis-backed sliding window rate limiter.
+/// Dual bucket: per-IP (rl:ip:{ip}) + per-API-key (rl:key:{hash}).
+/// Fail-open on Redis errors.
+/// </summary>
+public sealed class RateLimitMiddleware
+{
+    private const string ApiKeyHeader = "x-api-key";
+
+    /// <summary>
+    /// Atomic Lua script: remove expired entries, add current request, return count.
+    /// Uses Redis server time to avoid clock-drift issues.
+    /// </summary>
+    private static readonly LuaScript SlidingWindowScript = LuaScript.Prepare(
+        """
+        local key     = @key
+        local window  = tonumber(@window)
+        local member  = @member
+        local now     = redis.call('TIME')
+        local now_us  = tonumber(now[1]) * 1000000 + tonumber(now[2])
+        local min_score = now_us - window * 1000000
+        redis.call('ZREMRANGEBYSCORE', key, '-inf', min_score)
+        redis.call('ZADD', key, now_us, member)
+        redis.call('EXPIRE', key, window + 1)
+        return redis.call('ZCARD', key)
+        """);
+
+    private readonly RequestDelegate _next;
+    private readonly ILogger<RateLimitMiddleware> _logger;
+
+    public RateLimitMiddleware(RequestDelegate next, ILogger<RateLimitMiddleware> logger)
+    {
+        _next   = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(
+        HttpContext context,
+        IOptions<RateLimitOptions> options,
+        IConnectionMultiplexer? redis = null)
+    {
+        // If Redis is unavailable, fail-open
+        if (redis is null || !redis.IsConnected)
+        {
+            await _next(context);
+            return;
+        }
+
+        var opts      = options.Value;
+        var db        = redis.GetDatabase();
+        var clientIp  = GetClientIp(context);
+        var member    = $"{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}:{Guid.NewGuid():N}";
+
+        // Per-IP check
+        var ipResult = await EvalAsync(db, $"rl:ip:{clientIp}", opts.WindowSeconds, member);
+        if (!ipResult.IsSuccess)
+        {
+            _logger.LogWarning("Rate limit Redis error (IP): {Error}", ipResult.Error);
+            await _next(context);
+            return;
+        }
+
+        var ipRemaining = Math.Max(0, opts.IpPermitLimit - (int)ipResult.Value);
+        context.Response.Headers["X-RateLimit-Limit-Ip"]     = opts.IpPermitLimit.ToString();
+        context.Response.Headers["X-RateLimit-Remaining-Ip"] = ipRemaining.ToString();
+
+        if (ipResult.Value > opts.IpPermitLimit)
+        {
+            await Write429(context, opts.WindowSeconds);
+            return;
+        }
+
+        // Per-API-key check (only if header present)
+        if (context.Request.Headers.TryGetValue(ApiKeyHeader, out var rawKey)
+            && !string.IsNullOrWhiteSpace(rawKey))
+        {
+            var apiKey   = rawKey.ToString();
+            var keyId    = $"rl:key:{apiKey[..Math.Min(8, apiKey.Length)]}:{Hash(apiKey)}";
+            var keyMember = $"{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}:{Guid.NewGuid():N}";
+
+            var keyResult = await EvalAsync(db, keyId, opts.WindowSeconds, keyMember);
+            if (!keyResult.IsSuccess)
+            {
+                _logger.LogWarning("Rate limit Redis error (key): {Error}", keyResult.Error);
+                await _next(context);
+                return;
+            }
+
+            var keyRemaining = Math.Max(0, opts.ApiKeyPermitLimit - (int)keyResult.Value);
+            context.Response.Headers["X-RateLimit-Limit-Key"]     = opts.ApiKeyPermitLimit.ToString();
+            context.Response.Headers["X-RateLimit-Remaining-Key"] = keyRemaining.ToString();
+
+            if (keyResult.Value > opts.ApiKeyPermitLimit)
+            {
+                await Write429(context, opts.WindowSeconds);
+                return;
+            }
+        }
+
+        await _next(context);
+    }
+
+    private static async Task<RateLimitResult> EvalAsync(IDatabase db, string key, int windowSeconds, string member)
+    {
+        try
+        {
+            var result = await db.ScriptEvaluateAsync(
+                SlidingWindowScript,
+                new { key = (RedisKey)key, window = windowSeconds, member });
+            return RateLimitResult.Ok((long)result);
+        }
+        catch (Exception ex)
+        {
+            return RateLimitResult.Fail(ex.Message);
+        }
+    }
+
+    private static async Task Write429(HttpContext ctx, int windowSeconds)
+    {
+        ctx.Response.StatusCode  = StatusCodes.Status429TooManyRequests;
+        ctx.Response.ContentType = "application/json";
+        ctx.Response.Headers["Retry-After"] = windowSeconds.ToString();
+        await ctx.Response.WriteAsJsonAsync(new
+        {
+            error       = "rate_limit_exceeded",
+            retry_after = windowSeconds
+        });
+    }
+
+    private static string GetClientIp(HttpContext ctx)
+    {
+        if (ctx.Request.Headers.TryGetValue("X-Forwarded-For", out var fwd)
+            && !string.IsNullOrWhiteSpace(fwd))
+            return fwd.ToString().Split(',', StringSplitOptions.TrimEntries)[0];
+
+        return ctx.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+    }
+
+    /// <summary>SHA-256 prefix so full API key never appears in Redis key names.</summary>
+    private static string Hash(string input)
+    {
+        var bytes = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(bytes)[..16].ToLowerInvariant();
+    }
+
+    private readonly record struct RateLimitResult(bool IsSuccess, long Value, string? Error)
+    {
+        public static RateLimitResult Ok(long count)    => new(true,  count, null);
+        public static RateLimitResult Fail(string err)  => new(false, 0,     err);
+    }
+}
+
+public static class RateLimitMiddlewareExtensions
+{
+    public static IApplicationBuilder UseRateLimiting(this IApplicationBuilder app)
+        => app.UseMiddleware<RateLimitMiddleware>();
+}

--- a/src/AgentScope.Api/Middleware/RateLimitOptions.cs
+++ b/src/AgentScope.Api/Middleware/RateLimitOptions.cs
@@ -1,0 +1,17 @@
+namespace AgentScope.Api.Middleware;
+
+/// <summary>
+/// Configuration for the Redis sliding-window rate limiter.
+/// Binds to the "RateLimit" section in appsettings.json.
+/// </summary>
+public sealed class RateLimitOptions
+{
+    /// <summary>Max requests per window per client IP.</summary>
+    public int IpPermitLimit { get; set; } = 60;
+
+    /// <summary>Max requests per window per API key (header x-api-key).</summary>
+    public int ApiKeyPermitLimit { get; set; } = 300;
+
+    /// <summary>Sliding window duration in seconds.</summary>
+    public int WindowSeconds { get; set; } = 60;
+}

--- a/src/AgentScope.Api/Program.cs
+++ b/src/AgentScope.Api/Program.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Microsoft.EntityFrameworkCore;
-using System.Threading.RateLimiting;
 using AgentScope.Api;
 using AgentScope.Api.Agents;
 using AgentScope.Api.Middleware;
@@ -8,7 +7,6 @@ using AgentScope.Infrastructure;
 using AgentScope.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Identity;
-using Microsoft.AspNetCore.RateLimiting;
 using Microsoft.IdentityModel.Tokens;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -23,8 +21,11 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddHttpClient();
 
-// Infrastructure (DbContext, repositories, UoW)
+// Infrastructure (DbContext, repositories, UoW, Redis)
 builder.Services.AddInfrastructure(builder.Configuration);
+
+// Rate limiter options (Redis sliding window)
+builder.Services.Configure<RateLimitOptions>(builder.Configuration.GetSection("RateLimit"));
 
 // ASP.NET Core Identity (requires Microsoft.NET.Sdk.Web — stays in API layer)
 builder.Services.AddIdentity<IdentityUser, IdentityRole>()
@@ -63,19 +64,6 @@ builder.Services.AddScoped<MetricsAggregationAgent>();
 // Retention background job
 builder.Services.AddHostedService<RetentionCleanupService>();
 
-// Rate limiter — sliding window per api-key (per-second bursts)
-builder.Services.AddRateLimiter(options =>
-{
-    options.AddSlidingWindowLimiter("per-api-key", limiterOptions =>
-    {
-        limiterOptions.PermitLimit        = builder.Configuration.GetValue<int>("RateLimit:PermitLimit", 100);
-        limiterOptions.Window             = TimeSpan.FromSeconds(builder.Configuration.GetValue<int>("RateLimit:WindowSeconds", 60));
-        limiterOptions.SegmentsPerWindow  = 6;
-        limiterOptions.QueueProcessingOrder = QueueProcessingOrder.OldestFirst;
-        limiterOptions.QueueLimit         = 10;
-    });
-    options.RejectionStatusCode = StatusCodes.Status429TooManyRequests;
-});
 
 // ── App pipeline ──────────────────────────────────────────────────────────────
 var app = builder.Build();
@@ -125,12 +113,12 @@ app.MapGet("/health", () => Results.Ok(new { status = "healthy", ts = DateTime.U
 app.UseSwagger();
 app.UseSwaggerUI();
 
-app.UseRateLimiter();
-app.UseApiKeyAuth();   // validates x-api-key on /v1/* routes
+app.UseRateLimiting();  // Redis sliding window — before auth
+app.UseApiKeyAuth();    // validates x-api-key on /v1/* routes
 
 app.UseAuthentication();
 app.UseAuthorization();
-app.MapControllers().RequireRateLimiting("per-api-key");
+app.MapControllers();
 
 app.Run();
 

--- a/src/AgentScope.Api/appsettings.json
+++ b/src/AgentScope.Api/appsettings.json
@@ -8,10 +8,12 @@
   },
   "AllowedHosts": "*",
   "ConnectionStrings": {
-    "Postgres": "Host=localhost;Port=5432;Database=agentscope;Username=agentscope;Password=agentscope"
+    "Postgres": "Host=localhost;Port=5432;Database=agentscope;Username=agentscope;Password=agentscope",
+    "Redis": "localhost:6379"
   },
   "RateLimit": {
-    "PermitLimit": 100,
+    "IpPermitLimit": 60,
+    "ApiKeyPermitLimit": 300,
     "WindowSeconds": 60
   },
   "WebBaseUrl": "http://localhost:7001",

--- a/src/AgentScope.Infrastructure/DependencyInjection.cs
+++ b/src/AgentScope.Infrastructure/DependencyInjection.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using MonadicSharp.Persistence.Core;
 using MonadicSharp.Persistence.Implementations;
+using StackExchange.Redis;
 
 namespace AgentScope.Infrastructure;
 
@@ -44,9 +45,16 @@ public static class DependencyInjection
                     ?? Environment.GetEnvironmentVariable("REDIS_URL");
 
         if (!string.IsNullOrWhiteSpace(redisUrl))
+        {
             services.AddStackExchangeRedisCache(opts => opts.Configuration = redisUrl);
+            // Direct multiplexer for rate limiter (sorted-set sliding window)
+            services.AddSingleton<IConnectionMultiplexer>(_ =>
+                ConnectionMultiplexer.Connect(redisUrl));
+        }
         else
+        {
             services.AddDistributedMemoryCache();
+        }
 
         // Unit of Work wrapping the same DbContext scope
         services.AddScoped<IUnitOfWork>(sp =>


### PR DESCRIPTION
## Summary
- Sostituisce il rate limiter in-memory ASP.NET Core con Redis sliding window
- Dual bucket: 60 req/min per IP + 300 req/min per API key (`x-api-key`)
- Lua script atomico (ZREMRANGEBYSCORE + ZADD + ZCARD)
- Fail-open se Redis non disponibile
- `X-RateLimit-Remaining-{Ip,Key}` headers su ogni risposta

Closes #2

## Test plan
- [ ] Build verde ARM64 ✅
- [ ] 429 dopo 60 req/min dallo stesso IP
- [ ] Headers `X-RateLimit-Remaining-Ip` presenti
- [ ] Redis down → richieste passano (fail-open)

🤖 Generated with [Claude Code](https://claude.com/claude-code)