### PR TITLE
feat(p2): Stripe billing — checkout + webhook handler

### DIFF
--- a/src/AgentScope.Api/Controllers/BillingController.cs
+++ b/src/AgentScope.Api/Controllers/BillingController.cs
@@ -1,0 +1,59 @@
+using AgentScope.Domain.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgentScope.Api.Controllers;
+
+[ApiController]
+[Route("api/v1/billing")]
+public sealed class BillingController : ControllerBase
+{
+    private readonly IStripeService _stripe;
+    private readonly IConfiguration _config;
+
+    public BillingController(IStripeService stripe, IConfiguration config)
+    {
+        _stripe = stripe;
+        _config = config;
+    }
+
+    /// <summary>Creates a Stripe Checkout session and returns the redirect URL.</summary>
+    [HttpPost("checkout")]
+    [Authorize]
+    public async Task<IActionResult> CreateCheckout([FromBody] CreateCheckoutRequest request, CancellationToken ct)
+    {
+        var userIdClaim = User.FindFirst("AgentScope_UserId")?.Value;
+        if (!Guid.TryParse(userIdClaim, out var userId))
+            return Unauthorized(new { error = "Missing or invalid AgentScope_UserId claim." });
+
+        var priceId = request.PriceId ?? _config["Stripe:ProPriceId"] ?? string.Empty;
+        if (string.IsNullOrWhiteSpace(priceId))
+            return BadRequest(new { error = "priceId is required." });
+
+        var result = await _stripe.CreateCheckoutSessionAsync(userId, priceId, ct);
+        return result.Match<IActionResult>(
+            success => Ok(new { checkoutUrl = success }),
+            failure => BadRequest(new { error = failure.Message, code = failure.Code })
+        );
+    }
+
+    /// <summary>Receives Stripe webhook events. Must read raw body.</summary>
+    [HttpPost("webhook")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Webhook(CancellationToken ct)
+    {
+        string json;
+        using (var reader = new StreamReader(Request.Body))
+            json = await reader.ReadToEndAsync(ct);
+
+        var signature = Request.Headers["Stripe-Signature"].FirstOrDefault() ?? string.Empty;
+
+        var result = await _stripe.HandleWebhookEventAsync(json, signature, ct);
+        return result.Match<IActionResult>(
+            _ => Ok(),
+            failure => BadRequest(new { error = failure.Message, code = failure.Code })
+        );
+    }
+}
+
+public record CreateCheckoutRequest(string? PriceId);

--- a/src/AgentScope.Api/Program.cs
+++ b/src/AgentScope.Api/Program.cs
@@ -115,6 +115,7 @@ var app = builder.Build();
         );
         CREATE UNIQUE INDEX IF NOT EXISTS ix_prompts_app_slug_version ON prompts(application_id, slug, version);
         CREATE INDEX IF NOT EXISTS ix_prompts_app_slug_active ON prompts(application_id, slug, is_active);
+        ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS stripe_customer_id VARCHAR(64);
         """);
     if (app.Environment.IsDevelopment())
         await DevDataSeeder.SeedAsync(db);

--- a/src/AgentScope.Api/appsettings.json
+++ b/src/AgentScope.Api/appsettings.json
@@ -19,5 +19,14 @@
     "ClientId": "",
     "ClientSecret": "",
     "RedirectUri": "http://localhost:7000/api/v1/auth/github/callback"
+  },
+  "Stripe": {
+    "SecretKey": "",
+    "WebhookSecret": "",
+    "ProPriceId": "",
+    "BusinessPriceId": "",
+    "EnterprisePriceId": "",
+    "SuccessUrl": "https://app.agentscope.dev/billing/success",
+    "CancelUrl": "https://app.agentscope.dev/billing/cancel"
   }
 }

--- a/src/AgentScope.Domain/Entities/Subscription.cs
+++ b/src/AgentScope.Domain/Entities/Subscription.cs
@@ -17,8 +17,11 @@ public sealed class Subscription
     public DateTimeOffset CurrentPeriodEnd { get; private set; }
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
+    public string? StripeCustomerId { get; private set; }
 
     private Subscription() { StripeSubscriptionId = null!; StripePriceId = null!; }
+
+    public void SetStripeCustomerId(string customerId) => StripeCustomerId = customerId;
 
     public static Subscription Create(
         Guid userId,

--- a/src/AgentScope.Domain/Errors/DomainErrors.cs
+++ b/src/AgentScope.Domain/Errors/DomainErrors.cs
@@ -87,6 +87,20 @@ public static class DomainErrors
                  .WithMetadata("Model", model);
     }
 
+    public static class Stripe
+    {
+        public static Error CheckoutFailed(string detail) =>
+            Error.Create($"Stripe checkout failed: {detail}", "STRIPE_CHECKOUT_FAILED")
+                 .WithMetadata("Detail", detail);
+
+        public static Error WebhookVerificationFailed() =>
+            Error.Create("Stripe webhook signature verification failed.", "STRIPE_WEBHOOK_INVALID");
+
+        public static Error EventProcessingFailed(string eventType) =>
+            Error.Create($"Failed to process Stripe event '{eventType}'.", "STRIPE_EVENT_PROCESSING_FAILED")
+                 .WithMetadata("EventType", eventType);
+    }
+
     public static class Prompts
     {
         public static Error NotFound(string slug) =>

--- a/src/AgentScope.Domain/Services/IStripeService.cs
+++ b/src/AgentScope.Domain/Services/IStripeService.cs
@@ -1,0 +1,9 @@
+using MonadicSharp;
+
+namespace AgentScope.Domain.Services;
+
+public interface IStripeService
+{
+    Task<Result<string>> CreateCheckoutSessionAsync(Guid userId, string priceId, CancellationToken ct = default);
+    Task<Result<Unit>> HandleWebhookEventAsync(string json, string signature, CancellationToken ct = default);
+}

--- a/src/AgentScope.Infrastructure/AgentScope.Infrastructure.csproj
+++ b/src/AgentScope.Infrastructure/AgentScope.Infrastructure.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>AgentScope.Infrastructure</RootNamespace>
-    <NoWarn>$(NoWarn);CS8034</NoWarn>
+    <NoWarn>$(NoWarn);CS8034;CA1848</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,6 +17,7 @@
     <PackageReference Include="StackExchange.Redis" Version="2.8.16" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.2" />
+    <PackageReference Include="Stripe.net" Version="47.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/AgentScope.Infrastructure/DependencyInjection.cs
+++ b/src/AgentScope.Infrastructure/DependencyInjection.cs
@@ -38,6 +38,7 @@ public static class DependencyInjection
         services.AddScoped<ITokenUsageRepository,   TokenUsageRepository>();
         services.AddScoped<IPromptRepository,       PromptRepository>();
         services.AddSingleton<ILlmPricingService,   LlmPricingService>();
+        services.AddScoped<IStripeService,          StripeService>();
 
         // Distributed cache — Redis when REDIS_URL is set, otherwise in-memory fallback
         var redisUrl = configuration.GetConnectionString("Redis")

--- a/src/AgentScope.Infrastructure/Persistence/Configurations/SubscriptionConfiguration.cs
+++ b/src/AgentScope.Infrastructure/Persistence/Configurations/SubscriptionConfiguration.cs
@@ -19,5 +19,6 @@ public sealed class SubscriptionConfiguration : IEntityTypeConfiguration<Subscri
         builder.Property(s => s.CurrentPeriodEnd).IsRequired();
         builder.Property(s => s.CreatedAt).IsRequired();
         builder.Property(s => s.UpdatedAt).IsRequired();
+        builder.Property(s => s.StripeCustomerId).HasMaxLength(64).HasColumnName("stripe_customer_id");
     }
 }

--- a/src/AgentScope.Infrastructure/Services/StripeService.cs
+++ b/src/AgentScope.Infrastructure/Services/StripeService.cs
@@ -1,0 +1,175 @@
+using AgentScope.Domain.Entities;
+using AgentScope.Domain.Errors;
+using AgentScope.Domain.Ports;
+using AgentScope.Domain.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using MonadicSharp;
+using MonadicSharp.Persistence.Core;
+using Stripe;
+using Stripe.Checkout;
+
+namespace AgentScope.Infrastructure.Services;
+
+public sealed class StripeService : IStripeService
+{
+    private readonly ISubscriptionRepository _subscriptions;
+    private readonly IUserRepository _users;
+    private readonly IUnitOfWork _uow;
+    private readonly IConfiguration _config;
+    private readonly ILogger<StripeService> _logger;
+
+    public StripeService(
+        ISubscriptionRepository subscriptions,
+        IUserRepository users,
+        IUnitOfWork uow,
+        IConfiguration config,
+        ILogger<StripeService> logger)
+    {
+        _subscriptions = subscriptions;
+        _users         = users;
+        _uow           = uow;
+        _config        = config;
+        _logger        = logger;
+
+        StripeConfiguration.ApiKey = _config["Stripe:SecretKey"]
+            ?? throw new InvalidOperationException("Stripe:SecretKey is required.");
+    }
+
+    public async Task<Result<string>> CreateCheckoutSessionAsync(
+        Guid userId, string priceId, CancellationToken ct = default)
+    {
+        try
+        {
+            var successUrl = _config["Stripe:SuccessUrl"] ?? "https://app.agentscope.dev/billing/success";
+            var cancelUrl  = _config["Stripe:CancelUrl"]  ?? "https://app.agentscope.dev/billing/cancel";
+
+            var options = new SessionCreateOptions
+            {
+                Mode      = "subscription",
+                LineItems = [new SessionLineItemOptions { Price = priceId, Quantity = 1 }],
+                Metadata  = new Dictionary<string, string> { ["user_id"] = userId.ToString() },
+                SuccessUrl = successUrl,
+                CancelUrl  = cancelUrl,
+            };
+
+            var session = await new SessionService().CreateAsync(options, cancellationToken: ct);
+            return Result<string>.Success(session.Url);
+        }
+        catch (StripeException ex)
+        {
+            _logger.LogError(ex, "Stripe checkout session creation failed for user {UserId}", userId);
+            return Result<string>.Failure(DomainErrors.Stripe.CheckoutFailed(ex.Message));
+        }
+    }
+
+    public async Task<Result<Unit>> HandleWebhookEventAsync(
+        string json, string signature, CancellationToken ct = default)
+    {
+        var webhookSecret = _config["Stripe:WebhookSecret"] ?? string.Empty;
+
+        Event stripeEvent;
+        try
+        {
+            stripeEvent = EventUtility.ConstructEvent(json, signature, webhookSecret);
+        }
+        catch (StripeException ex)
+        {
+            _logger.LogWarning(ex, "Stripe webhook signature verification failed");
+            return Result<Unit>.Failure(DomainErrors.Stripe.WebhookVerificationFailed());
+        }
+
+        try
+        {
+            return stripeEvent.Type switch
+            {
+                "checkout.session.completed"      => await HandleCheckoutCompletedAsync(stripeEvent, ct),
+                "customer.subscription.deleted"   => await HandleSubscriptionDeletedAsync(stripeEvent, ct),
+                _                                 => Result<Unit>.Success(Unit.Value),
+            };
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error processing Stripe event {EventType}", stripeEvent.Type);
+            return Result<Unit>.Failure(DomainErrors.Stripe.EventProcessingFailed(stripeEvent.Type));
+        }
+    }
+
+    private async Task<Result<Unit>> HandleCheckoutCompletedAsync(Event stripeEvent, CancellationToken ct)
+    {
+        if (stripeEvent.Data.Object is not Session session)
+            return Result<Unit>.Failure(DomainErrors.Stripe.EventProcessingFailed(stripeEvent.Type));
+
+        if (!session.Metadata.TryGetValue("user_id", out var userIdStr)
+            || !Guid.TryParse(userIdStr, out var userId))
+            return Result<Unit>.Failure(DomainErrors.Stripe.EventProcessingFailed(stripeEvent.Type));
+
+        var userResult = await _users.GetByIdAsync(userId, ct);
+        if (!userResult.IsSuccess)
+            return Result<Unit>.Failure(userResult.Error!);
+
+        var user = userResult.Value!;
+        var tier = MapPriceIdToTier(session);
+
+        var subscription = AgentScope.Domain.Entities.Subscription.Create(
+            userId:               userId,
+            stripeSubscriptionId: session.SubscriptionId ?? string.Empty,
+            stripePriceId:        session.Subscription?.ToString() ?? string.Empty,
+            tier:                 tier,
+            periodStart:          DateTimeOffset.UtcNow,
+            periodEnd:            DateTimeOffset.UtcNow.AddMonths(1));
+
+        subscription.SetStripeCustomerId(session.CustomerId ?? string.Empty);
+        user.UpgradeTier(tier);
+
+        var addResult = await _subscriptions.AddAsync(subscription, ct);
+        if (!addResult.IsSuccess) return addResult;
+
+        var updateResult = await _users.UpdateAsync(user, ct);
+        if (!updateResult.IsSuccess) return updateResult;
+
+        await _uow.SaveChangesAsync(ct);
+        return Result<Unit>.Success(Unit.Value);
+    }
+
+    private async Task<Result<Unit>> HandleSubscriptionDeletedAsync(Event stripeEvent, CancellationToken ct)
+    {
+        if (stripeEvent.Data.Object is not global::Stripe.Subscription stripeSub)
+            return Result<Unit>.Failure(DomainErrors.Stripe.EventProcessingFailed(stripeEvent.Type));
+
+        var subResult = await _subscriptions.GetByStripeIdAsync(stripeSub.Id, ct);
+        if (!subResult.IsSuccess)
+            return Result<Unit>.Failure(subResult.Error!);
+
+        var subscription = subResult.Value!;
+        subscription.Cancel();
+
+        var userResult = await _users.GetByIdAsync(subscription.UserId, ct);
+        if (!userResult.IsSuccess)
+            return Result<Unit>.Failure(userResult.Error!);
+
+        userResult.Value!.UpgradeTier(SubscriptionTier.Free);
+
+        var updateSubResult = await _subscriptions.UpdateAsync(subscription, ct);
+        if (!updateSubResult.IsSuccess) return updateSubResult;
+
+        var updateUserResult = await _users.UpdateAsync(userResult.Value!, ct);
+        if (!updateUserResult.IsSuccess) return updateUserResult;
+
+        await _uow.SaveChangesAsync(ct);
+        return Result<Unit>.Success(Unit.Value);
+    }
+
+    private SubscriptionTier MapPriceIdToTier(Session session)
+    {
+        var priceId = session.LineItems?.Data?.Count > 0
+            ? session.LineItems.Data[0].Price?.Id ?? string.Empty
+            : string.Empty;
+
+        if (priceId == _config["Stripe:EnterprisePriceId"]) return SubscriptionTier.Enterprise;
+        if (priceId == _config["Stripe:BusinessPriceId"])   return SubscriptionTier.Business;
+        if (priceId == _config["Stripe:ProPriceId"])        return SubscriptionTier.Pro;
+
+        return SubscriptionTier.Pro;
+    }
+}


### PR DESCRIPTION
## Summary
- `IStripeService` port + `StripeService` implementation (Result<T> throughout)
- `POST /api/v1/billing/checkout` → crea sessione Stripe, ritorna URL
- `POST /api/v1/billing/webhook` → gestisce `checkout.session.completed` e `customer.subscription.deleted`
- `StripeCustomerId` aggiunto a entità `Subscription` + colonna DB idempotente
- Config via `appsettings.json`, zero credenziali hardcoded

Closes #3

## Test plan
- [ ] Build verde ARM64 ✅
- [ ] `POST /checkout` con JWT → ritorna `checkoutUrl`
- [ ] Webhook `checkout.session.completed` → crea Subscription + UpgradeTier
- [ ] Webhook con firma invalida → 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)