### PR TITLE
feat(p4-evals): thumbs up/down evaluation widget on traces

### DIFF
--- a/src/AgentScope.Api/Controllers/EvaluationsController.cs
+++ b/src/AgentScope.Api/Controllers/EvaluationsController.cs
@@ -1,0 +1,56 @@
+using AgentScope.Domain.Entities;
+using AgentScope.Domain.Ports;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgentScope.Api.Controllers;
+
+public record EvalDto(Guid Id, Guid TraceId, Guid ApplicationId, EvalScore Score, string? Label, string? Note, DateTimeOffset CreatedAt);
+public record SaveEvalRequest(Guid TraceId, Guid ApplicationId, EvalScore Score, string? Label, string? Note);
+
+[ApiController]
+[Authorize]
+[Route("api/v1/evals")]
+public sealed class EvaluationsController : ControllerBase
+{
+    private readonly IEvaluationRepository _repo;
+    public EvaluationsController(IEvaluationRepository repo) => _repo = repo;
+
+    private Guid? GetUserId()
+    {
+        var claim = User.FindFirst("AgentScope_UserId");
+        return claim != null && Guid.TryParse(claim.Value, out var id) ? id : null;
+    }
+
+    /// <summary>Save or update evaluation for a trace.</summary>
+    [HttpPost]
+    public async Task<IActionResult> Save([FromBody] SaveEvalRequest req, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var eval   = Evaluation.Create(req.TraceId, req.ApplicationId, req.Score, req.Label, req.Note, userId);
+        var result = await _repo.SaveAsync(eval, ct);
+        if (!result.IsSuccess) return StatusCode(500, new { error = result.Error.Message });
+        return Ok(ToDto(eval));
+    }
+
+    /// <summary>Get evaluation for a specific trace.</summary>
+    [HttpGet("trace/{traceId:guid}")]
+    public async Task<IActionResult> GetByTrace(Guid traceId, CancellationToken ct)
+    {
+        var result = await _repo.GetByTraceAsync(traceId, ct);
+        if (!result.IsSuccess) return StatusCode(500, new { error = result.Error.Message });
+        return result.Value is null ? NotFound() : Ok(ToDto(result.Value));
+    }
+
+    /// <summary>Get aggregate evaluation stats for an application.</summary>
+    [HttpGet("aggregate/{appId:guid}")]
+    public async Task<IActionResult> GetAggregate(Guid appId, CancellationToken ct)
+    {
+        var result = await _repo.GetAggregateAsync(appId, ct);
+        if (!result.IsSuccess) return StatusCode(500, new { error = result.Error.Message });
+        return Ok(result.Value);
+    }
+
+    private static EvalDto ToDto(Evaluation e) =>
+        new(e.Id, e.TraceId, e.ApplicationId, e.Score, e.Label, e.Note, e.CreatedAt);
+}

--- a/src/AgentScope.Domain/Entities/Evaluation.cs
+++ b/src/AgentScope.Domain/Entities/Evaluation.cs
@@ -1,0 +1,39 @@
+namespace AgentScope.Domain.Entities;
+
+public sealed class Evaluation
+{
+    public Guid           Id            { get; private set; }
+    public Guid           TraceId       { get; private set; }
+    public Guid           ApplicationId { get; private set; }
+    public EvalScore      Score         { get; private set; }
+    public string?        Label         { get; private set; }
+    public string?        Note          { get; private set; }
+    public Guid?          ReviewedBy    { get; private set; }
+    public DateTimeOffset CreatedAt     { get; private set; }
+
+    private Evaluation() { }
+
+    public static Evaluation Create(
+        Guid traceId, Guid applicationId, EvalScore score,
+        string? label, string? note, Guid? reviewedBy) => new()
+    {
+        Id            = Guid.NewGuid(),
+        TraceId       = traceId,
+        ApplicationId = applicationId,
+        Score         = score,
+        Label         = label,
+        Note          = note,
+        ReviewedBy    = reviewedBy,
+        CreatedAt     = DateTimeOffset.UtcNow,
+    };
+
+    public void Update(EvalScore score, string? label, string? note, Guid? reviewedBy)
+    {
+        Score      = score;
+        Label      = label;
+        Note       = note;
+        ReviewedBy = reviewedBy;
+    }
+}
+
+public enum EvalScore { ThumbsDown = -1, Neutral = 0, ThumbsUp = 1 }

--- a/src/AgentScope.Domain/Ports/IEvaluationRepository.cs
+++ b/src/AgentScope.Domain/Ports/IEvaluationRepository.cs
@@ -1,0 +1,13 @@
+using AgentScope.Domain.Entities;
+using MonadicSharp;
+
+namespace AgentScope.Domain.Ports;
+
+public record EvalAggregate(int Total, int ThumbsUp, int ThumbsDown, int Neutral, double PositiveRate);
+
+public interface IEvaluationRepository
+{
+    Task<Result<Unit>>          SaveAsync(Evaluation eval, CancellationToken ct = default);
+    Task<Result<Evaluation?>>   GetByTraceAsync(Guid traceId, CancellationToken ct = default);
+    Task<Result<EvalAggregate>> GetAggregateAsync(Guid applicationId, CancellationToken ct = default);
+}

--- a/src/AgentScope.Infrastructure/DependencyInjection.cs
+++ b/src/AgentScope.Infrastructure/DependencyInjection.cs
@@ -38,6 +38,7 @@ public static class DependencyInjection
         services.AddScoped<IMetricRepository,       MetricRepository>();
         services.AddScoped<ITokenUsageRepository,   TokenUsageRepository>();
         services.AddScoped<IPromptRepository,       PromptRepository>();
+        services.AddScoped<IEvaluationRepository,   EvaluationRepository>();
         services.AddSingleton<ILlmPricingService,   LlmPricingService>();
         services.AddScoped<IStripeService,          StripeService>();
 

--- a/src/AgentScope.Infrastructure/Persistence/AgentScopeDbContext.cs
+++ b/src/AgentScope.Infrastructure/Persistence/AgentScopeDbContext.cs
@@ -24,6 +24,7 @@ public sealed class AgentScopeDbContext : IdentityDbContext<IdentityUser>
     public DbSet<MetricPoint>  MetricPoints  => Set<MetricPoint>();
     public DbSet<TokenUsage>   TokenUsages   => Set<TokenUsage>();
     public DbSet<Prompt>       Prompts        => Set<Prompt>();
+    public DbSet<Evaluation>   Evaluations    => Set<Evaluation>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -38,5 +39,6 @@ public sealed class AgentScopeDbContext : IdentityDbContext<IdentityUser>
         builder.ApplyConfiguration(new MetricPointConfiguration());
         builder.ApplyConfiguration(new TokenUsageConfiguration());
         builder.ApplyConfiguration(new PromptConfiguration());
+        builder.ApplyConfiguration(new EvaluationConfiguration());
     }
 }

--- a/src/AgentScope.Infrastructure/Persistence/Configurations/EvaluationConfiguration.cs
+++ b/src/AgentScope.Infrastructure/Persistence/Configurations/EvaluationConfiguration.cs
@@ -1,0 +1,23 @@
+using AgentScope.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AgentScope.Infrastructure.Persistence.Configurations;
+
+public sealed class EvaluationConfiguration : IEntityTypeConfiguration<Evaluation>
+{
+    public void Configure(EntityTypeBuilder<Evaluation> builder)
+    {
+        builder.ToTable("Evaluations");
+        builder.HasKey(e => e.Id);
+        builder.Property(e => e.TraceId).IsRequired();
+        builder.Property(e => e.ApplicationId).IsRequired();
+        builder.Property(e => e.Score).HasConversion<int>().IsRequired();
+        builder.Property(e => e.Label).HasMaxLength(200);
+        builder.Property(e => e.Note).HasMaxLength(2000);
+        builder.Property(e => e.CreatedAt).IsRequired();
+
+        builder.HasIndex(e => e.TraceId).IsUnique();
+        builder.HasIndex(e => e.ApplicationId);
+    }
+}

--- a/src/AgentScope.Infrastructure/Persistence/Repositories/EvaluationRepository.cs
+++ b/src/AgentScope.Infrastructure/Persistence/Repositories/EvaluationRepository.cs
@@ -1,0 +1,45 @@
+using AgentScope.Domain.Entities;
+using AgentScope.Domain.Ports;
+using Microsoft.EntityFrameworkCore;
+using MonadicSharp;
+
+namespace AgentScope.Infrastructure.Persistence.Repositories;
+
+public sealed class EvaluationRepository : IEvaluationRepository
+{
+    private readonly AgentScopeDbContext _db;
+    public EvaluationRepository(AgentScopeDbContext db) => _db = db;
+
+    public async Task<Result<Unit>> SaveAsync(Evaluation eval, CancellationToken ct = default)
+    {
+        var existing = await _db.Evaluations.FirstOrDefaultAsync(e => e.TraceId == eval.TraceId, ct);
+        if (existing is null)
+            await _db.Evaluations.AddAsync(eval, ct);
+        else
+            existing.Update(eval.Score, eval.Label, eval.Note, eval.ReviewedBy);
+        await _db.SaveChangesAsync(ct);
+        return Result<Unit>.Success(Unit.Value);
+    }
+
+    public async Task<Result<Evaluation?>> GetByTraceAsync(Guid traceId, CancellationToken ct = default)
+    {
+        var eval = await _db.Evaluations.FirstOrDefaultAsync(e => e.TraceId == traceId, ct);
+        return Result<Evaluation?>.Success(eval);
+    }
+
+    public async Task<Result<EvalAggregate>> GetAggregateAsync(Guid applicationId, CancellationToken ct = default)
+    {
+        var scores = await _db.Evaluations
+            .Where(e => e.ApplicationId == applicationId)
+            .Select(e => e.Score)
+            .ToListAsync(ct);
+
+        int    total      = scores.Count;
+        int    thumbsUp   = scores.Count(s => s == EvalScore.ThumbsUp);
+        int    thumbsDown = scores.Count(s => s == EvalScore.ThumbsDown);
+        int    neutral    = scores.Count(s => s == EvalScore.Neutral);
+        double rate       = total > 0 ? thumbsUp * 100.0 / total : 0.0;
+
+        return Result<EvalAggregate>.Success(new EvalAggregate(total, thumbsUp, thumbsDown, neutral, rate));
+    }
+}

--- a/src/AgentScope.Web/Components/Pages/TraceDetail.razor
+++ b/src/AgentScope.Web/Components/Pages/TraceDetail.razor
@@ -66,6 +66,41 @@ else
         </div>
     </MudPaper>
 
+    <!-- Eval Panel -->
+    <MudPaper Class="pa-4 mb-4" Elevation="0"
+              Style="border:1px solid #1F2937; border-radius:12px;">
+        <div style="display:flex; align-items:center; gap:16px; flex-wrap:wrap;">
+            <MudText Typo="Typo.body2" Style="color:#9CA3AF; font-size:.8rem; text-transform:uppercase; letter-spacing:.05em;">
+                Rate this trace
+            </MudText>
+            <MudIconButton Icon="@Icons.Material.Filled.ThumbUp"
+                           Color="@(_eval?.Score == EvalScore.ThumbsUp ? Color.Success : Color.Default)"
+                           Size="Size.Small"
+                           OnClick="@(() => RateAsync(EvalScore.ThumbsUp))"
+                           title="Good" />
+            <MudIconButton Icon="@Icons.Material.Filled.ThumbsUpDown"
+                           Color="@(_eval?.Score == EvalScore.Neutral ? Color.Warning : Color.Default)"
+                           Size="Size.Small"
+                           OnClick="@(() => RateAsync(EvalScore.Neutral))"
+                           title="Neutral" />
+            <MudIconButton Icon="@Icons.Material.Filled.ThumbDown"
+                           Color="@(_eval?.Score == EvalScore.ThumbsDown ? Color.Error : Color.Default)"
+                           Size="Size.Small"
+                           OnClick="@(() => RateAsync(EvalScore.ThumbsDown))"
+                           title="Bad" />
+            @if (_eval is not null)
+            {
+                var scoreLbl = _eval.Score switch {
+                    EvalScore.ThumbsUp   => ("👍 Good",    "#10B981"),
+                    EvalScore.Neutral    => ("↔ Neutral",  "#F59E0B"),
+                    EvalScore.ThumbsDown => ("👎 Bad",     "#EF4444"),
+                    _                   => ("",             "#6B7280"),
+                };
+                <span style="font-size:.78rem; color:@scoreLbl.Item2; font-weight:600;">@scoreLbl.Item1</span>
+            }
+        </div>
+    </MudPaper>
+
     <!-- Waterfall -->
     <MudText Typo="Typo.subtitle1" Class="mb-3" Style="font-weight:600; color:#F9FAFB;">Span Waterfall</MudText>
     <MudPaper Elevation="0" Class="mb-6" Style="border:1px solid #1F2937; border-radius:12px; overflow:hidden;">
@@ -172,6 +207,7 @@ else
     private List<Span>        _spans        = [];
     private List<RailwayNode> _railwayRoots = [];
     private bool              _loaded;
+    private Evaluation?       _eval;
 
     private List<BreadcrumbItem> _breadcrumbs =
     [
@@ -185,7 +221,16 @@ else
         _trace        = await Svc.GetTraceDetailAsync(Id);
         _spans        = _trace?.Spans.ToList() ?? [];
         _railwayRoots = await Svc.GetRailwayGraphAsync(Id);
+        _eval         = await Svc.GetEvalForTraceAsync(Id);
         _loaded       = true;
+    }
+
+    private async Task RateAsync(EvalScore score)
+    {
+        if (_trace is null) return;
+        await Svc.SaveEvalAsync(_trace.Id, _trace.ApplicationId, score, null, null);
+        _eval = await Svc.GetEvalForTraceAsync(_trace.Id);
+        StateHasChanged();
     }
 
     private static bool HasRailwayOp(RailwayNode n) =>

--- a/src/AgentScope.Web/Services/DashboardService.cs
+++ b/src/AgentScope.Web/Services/DashboardService.cs
@@ -387,6 +387,30 @@ public sealed class DashboardService
     private static PromptSummary ToSummary(Prompt p) =>
         new(p.Id, p.ApplicationId, p.Slug, p.Version, p.Content, p.ChangeNote, p.IsActive, p.PublishedAt);
 
+    // ── Evaluations ─────────────────────────────────────────────────────────────
+
+    public async Task<Evaluation?> GetEvalForTraceAsync(Guid traceId, CancellationToken ct = default)
+    {
+        await using var db = _factory.CreateDbContext();
+        return await db.Evaluations.FirstOrDefaultAsync(e => e.TraceId == traceId, ct);
+    }
+
+    public async Task SaveEvalAsync(Guid traceId, Guid applicationId, EvalScore score, string? note, Guid? userId, CancellationToken ct = default)
+    {
+        await using var db = _factory.CreateDbContext();
+        var existing = await db.Evaluations.FirstOrDefaultAsync(e => e.TraceId == traceId, ct);
+        if (existing is null)
+        {
+            var eval = Evaluation.Create(traceId, applicationId, score, null, note, userId);
+            await db.Evaluations.AddAsync(eval, ct);
+        }
+        else
+        {
+            existing.Update(score, existing.Label, note, userId);
+        }
+        await db.SaveChangesAsync(ct);
+    }
+
     private static async Task<List<Guid>?> GetUserAppIdsAsync(AgentScopeDbContext db, Guid? userId, CancellationToken ct)
     {
         if (!userId.HasValue) return null;


### PR DESCRIPTION
## Summary
- `Evaluation` entity with `EvalScore` enum (ThumbsUp / Neutral / ThumbsDown)
- `EvaluationsController` at `api/v1/evals` (JWT auth): POST save, GET by trace, GET aggregate
- `DashboardService`: `GetEvalForTraceAsync` + `SaveEvalAsync` (direct EF, no extra HTTP hop)
- `TraceDetail.razor`: rating panel with 3 icon buttons + live color feedback

## Test plan
- [ ] Open any trace → rating panel visible between header and waterfall
- [ ] Click 👍 → button turns green, label "👍 Good" appears
- [ ] Click 👎 → button turns red, label "👎 Bad" appears  
- [ ] Refresh page → rating persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)