### PR TITLE
feat(p4-hitl): human-in-the-loop review queue

### DIFF
--- a/src/AgentScope.Api/Controllers/HitlController.cs
+++ b/src/AgentScope.Api/Controllers/HitlController.cs
@@ -1,0 +1,83 @@
+using AgentScope.Api.Middleware;
+using AgentScope.Domain.Entities;
+using AgentScope.Domain.Ports;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace AgentScope.Api.Controllers;
+
+public record HitlReviewDto(Guid Id, Guid TraceId, Guid ApplicationId, string Action, string? Payload, HitlStatus Status, string? ReviewNote, DateTimeOffset CreatedAt, DateTimeOffset? ReviewedAt);
+public record CreateHitlRequest(Guid TraceId, string Action, string? Payload);
+public record ReviewHitlRequest(HitlStatus Status, string? Note);
+
+// ── SDK endpoints (v1/hitl — API key auth) ────────────────────────────────────
+[ApiController]
+[Route("v1/hitl")]
+public sealed class SdkHitlController : ControllerBase
+{
+    private readonly IHitlReviewRepository _repo;
+    public SdkHitlController(IHitlReviewRepository repo) => _repo = repo;
+
+    [HttpPost]
+    public async Task<IActionResult> Create([FromBody] CreateHitlRequest req, CancellationToken ct)
+    {
+        var app = HttpContext.Items[ApiKeyMiddleware.ApplicationKey] as Application;
+        if (app is null) return Unauthorized();
+        var review = HitlReview.Create(req.TraceId, app.Id, req.Action, req.Payload);
+        var result = await _repo.CreateAsync(review, ct);
+        if (!result.IsSuccess) return StatusCode(500, new { error = result.Error.Message });
+        return CreatedAtAction(nameof(GetStatus), new { id = review.Id }, ToDto(review));
+    }
+
+    [HttpGet("{id:guid}/status")]
+    public async Task<IActionResult> GetStatus(Guid id, CancellationToken ct)
+    {
+        var app = HttpContext.Items[ApiKeyMiddleware.ApplicationKey] as Application;
+        if (app is null) return Unauthorized();
+        var result = await _repo.GetAsync(id, ct);
+        if (!result.IsSuccess) return StatusCode(500, new { error = result.Error.Message });
+        if (result.Value is null || result.Value.ApplicationId != app.Id) return NotFound();
+        return Ok(new { id = result.Value.Id, status = result.Value.Status.ToString() });
+    }
+
+    private static HitlReviewDto ToDto(HitlReview h) =>
+        new(h.Id, h.TraceId, h.ApplicationId, h.Action, h.Payload, h.Status, h.ReviewNote, h.CreatedAt, h.ReviewedAt);
+}
+
+// ── Management endpoints (api/v1/hitl — JWT auth) ─────────────────────────────
+[ApiController]
+[Authorize]
+[Route("api/v1/hitl")]
+public sealed class HitlManagementController : ControllerBase
+{
+    private readonly IHitlReviewRepository _repo;
+    public HitlManagementController(IHitlReviewRepository repo) => _repo = repo;
+
+    private Guid? GetUserId()
+    {
+        var claim = User.FindFirst("AgentScope_UserId");
+        return claim != null && Guid.TryParse(claim.Value, out var id) ? id : null;
+    }
+
+    [HttpGet("pending/{appId:guid}")]
+    public async Task<IActionResult> GetPending(Guid appId, CancellationToken ct)
+    {
+        var result = await _repo.GetPendingAsync(appId, ct);
+        if (!result.IsSuccess) return StatusCode(500, new { error = result.Error.Message });
+        return Ok(result.Value.Select(ToDto));
+    }
+
+    [HttpPut("{id:guid}/review")]
+    public async Task<IActionResult> Review(Guid id, [FromBody] ReviewHitlRequest req, CancellationToken ct)
+    {
+        var userId = GetUserId();
+        var result = await _repo.ReviewAsync(id, req.Status, req.Note, userId, ct);
+        if (!result.IsSuccess) return result.Error.Code == "HITL_NOT_FOUND"
+            ? NotFound(new { error = result.Error.Message })
+            : StatusCode(500, new { error = result.Error.Message });
+        return NoContent();
+    }
+
+    private static HitlReviewDto ToDto(HitlReview h) =>
+        new(h.Id, h.TraceId, h.ApplicationId, h.Action, h.Payload, h.Status, h.ReviewNote, h.CreatedAt, h.ReviewedAt);
+}

--- a/src/AgentScope.Domain/Entities/HitlReview.cs
+++ b/src/AgentScope.Domain/Entities/HitlReview.cs
@@ -1,0 +1,38 @@
+namespace AgentScope.Domain.Entities;
+
+public enum HitlStatus { Pending, Approved, Rejected }
+
+public sealed class HitlReview
+{
+    public Guid           Id            { get; private set; }
+    public Guid           TraceId       { get; private set; }
+    public Guid           ApplicationId { get; private set; }
+    public string         Action        { get; private set; } = string.Empty;
+    public string?        Payload       { get; private set; }
+    public HitlStatus     Status        { get; private set; }
+    public string?        ReviewNote    { get; private set; }
+    public Guid?          ReviewedBy    { get; private set; }
+    public DateTimeOffset CreatedAt     { get; private set; }
+    public DateTimeOffset? ReviewedAt   { get; private set; }
+
+    private HitlReview() { }
+
+    public static HitlReview Create(Guid traceId, Guid applicationId, string action, string? payload) => new()
+    {
+        Id            = Guid.NewGuid(),
+        TraceId       = traceId,
+        ApplicationId = applicationId,
+        Action        = action,
+        Payload       = payload,
+        Status        = HitlStatus.Pending,
+        CreatedAt     = DateTimeOffset.UtcNow,
+    };
+
+    public void Review(HitlStatus status, string? note, Guid? reviewedBy)
+    {
+        Status     = status;
+        ReviewNote = note;
+        ReviewedBy = reviewedBy;
+        ReviewedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/src/AgentScope.Domain/Ports/IHitlReviewRepository.cs
+++ b/src/AgentScope.Domain/Ports/IHitlReviewRepository.cs
@@ -1,0 +1,12 @@
+using AgentScope.Domain.Entities;
+using MonadicSharp;
+
+namespace AgentScope.Domain.Ports;
+
+public interface IHitlReviewRepository
+{
+    Task<Result<Unit>>             CreateAsync(HitlReview review, CancellationToken ct = default);
+    Task<Result<HitlReview?>>      GetAsync(Guid id, CancellationToken ct = default);
+    Task<Result<List<HitlReview>>> GetPendingAsync(Guid applicationId, CancellationToken ct = default);
+    Task<Result<Unit>>             ReviewAsync(Guid id, HitlStatus status, string? note, Guid? reviewedBy, CancellationToken ct = default);
+}

--- a/src/AgentScope.Infrastructure/DependencyInjection.cs
+++ b/src/AgentScope.Infrastructure/DependencyInjection.cs
@@ -38,6 +38,7 @@ public static class DependencyInjection
         services.AddScoped<IMetricRepository,       MetricRepository>();
         services.AddScoped<ITokenUsageRepository,   TokenUsageRepository>();
         services.AddScoped<IPromptRepository,       PromptRepository>();
+        services.AddScoped<IHitlReviewRepository,   HitlReviewRepository>();
         services.AddSingleton<ILlmPricingService,   LlmPricingService>();
         services.AddScoped<IStripeService,          StripeService>();
 

--- a/src/AgentScope.Infrastructure/Persistence/AgentScopeDbContext.cs
+++ b/src/AgentScope.Infrastructure/Persistence/AgentScopeDbContext.cs
@@ -24,6 +24,7 @@ public sealed class AgentScopeDbContext : IdentityDbContext<IdentityUser>
     public DbSet<MetricPoint>  MetricPoints  => Set<MetricPoint>();
     public DbSet<TokenUsage>   TokenUsages   => Set<TokenUsage>();
     public DbSet<Prompt>       Prompts        => Set<Prompt>();
+    public DbSet<HitlReview>   HitlReviews    => Set<HitlReview>();
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -38,5 +39,6 @@ public sealed class AgentScopeDbContext : IdentityDbContext<IdentityUser>
         builder.ApplyConfiguration(new MetricPointConfiguration());
         builder.ApplyConfiguration(new TokenUsageConfiguration());
         builder.ApplyConfiguration(new PromptConfiguration());
+        builder.ApplyConfiguration(new HitlReviewConfiguration());
     }
 }

--- a/src/AgentScope.Infrastructure/Persistence/Configurations/HitlReviewConfiguration.cs
+++ b/src/AgentScope.Infrastructure/Persistence/Configurations/HitlReviewConfiguration.cs
@@ -1,0 +1,25 @@
+using AgentScope.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace AgentScope.Infrastructure.Persistence.Configurations;
+
+public sealed class HitlReviewConfiguration : IEntityTypeConfiguration<HitlReview>
+{
+    public void Configure(EntityTypeBuilder<HitlReview> builder)
+    {
+        builder.ToTable("HitlReviews");
+        builder.HasKey(h => h.Id);
+        builder.Property(h => h.TraceId).IsRequired();
+        builder.Property(h => h.ApplicationId).IsRequired();
+        builder.Property(h => h.Action).IsRequired().HasMaxLength(500);
+        builder.Property(h => h.Payload).HasMaxLength(8000);
+        builder.Property(h => h.Status).HasConversion<int>().IsRequired();
+        builder.Property(h => h.ReviewNote).HasMaxLength(2000);
+        builder.Property(h => h.CreatedAt).IsRequired();
+
+        builder.HasIndex(h => h.ApplicationId);
+        builder.HasIndex(h => h.Status);
+        builder.HasIndex(h => new { h.ApplicationId, h.Status });
+    }
+}

--- a/src/AgentScope.Infrastructure/Persistence/Repositories/HitlReviewRepository.cs
+++ b/src/AgentScope.Infrastructure/Persistence/Repositories/HitlReviewRepository.cs
@@ -1,0 +1,44 @@
+using AgentScope.Domain.Entities;
+using AgentScope.Domain.Ports;
+using Microsoft.EntityFrameworkCore;
+using MonadicSharp;
+
+namespace AgentScope.Infrastructure.Persistence.Repositories;
+
+public sealed class HitlReviewRepository : IHitlReviewRepository
+{
+    private readonly AgentScopeDbContext _db;
+    public HitlReviewRepository(AgentScopeDbContext db) => _db = db;
+
+    public async Task<Result<Unit>> CreateAsync(HitlReview review, CancellationToken ct = default)
+    {
+        await _db.HitlReviews.AddAsync(review, ct);
+        await _db.SaveChangesAsync(ct);
+        return Result<Unit>.Success(Unit.Value);
+    }
+
+    public async Task<Result<HitlReview?>> GetAsync(Guid id, CancellationToken ct = default)
+    {
+        var review = await _db.HitlReviews.FirstOrDefaultAsync(h => h.Id == id, ct);
+        return Result<HitlReview?>.Success(review);
+    }
+
+    public async Task<Result<List<HitlReview>>> GetPendingAsync(Guid applicationId, CancellationToken ct = default)
+    {
+        var items = await _db.HitlReviews
+            .Where(h => h.ApplicationId == applicationId && h.Status == HitlStatus.Pending)
+            .OrderBy(h => h.CreatedAt)
+            .ToListAsync(ct);
+        return Result<List<HitlReview>>.Success(items);
+    }
+
+    public async Task<Result<Unit>> ReviewAsync(Guid id, HitlStatus status, string? note, Guid? reviewedBy, CancellationToken ct = default)
+    {
+        var review = await _db.HitlReviews.FirstOrDefaultAsync(h => h.Id == id, ct);
+        if (review is null)
+            return Result<Unit>.Failure(Error.Create($"HitlReview {id} not found.", "HITL_NOT_FOUND"));
+        review.Review(status, note, reviewedBy);
+        await _db.SaveChangesAsync(ct);
+        return Result<Unit>.Success(Unit.Value);
+    }
+}

--- a/src/AgentScope.Web/Components/Layout/MainLayout.razor
+++ b/src/AgentScope.Web/Components/Layout/MainLayout.razor
@@ -69,6 +69,7 @@
                         Icon="@Icons.Material.Outlined.TextSnippet">
                 Prompts
             </MudNavLink>
+            <MudNavLink Href="/hitl" Icon="@Icons.Material.Filled.HowToReg" Match="NavLinkMatch.Prefix">HITL Queue</MudNavLink>
         </MudNavMenu>
     </MudDrawer>
 

--- a/src/AgentScope.Web/Components/Pages/HitlQueue.razor
+++ b/src/AgentScope.Web/Components/Pages/HitlQueue.razor
@@ -1,0 +1,102 @@
+@page "/hitl"
+@attribute [Authorize]
+@inject DashboardService Svc
+@inject NavigationManager Nav
+@using AgentScope.Domain.Entities
+
+<PageTitle>HITL Queue — AgentScope</PageTitle>
+
+<MudBreadcrumbs Items="_breadcrumbs" Class="mb-4 pa-0" />
+
+<MudText Typo="Typo.h5" Style="font-weight:700; color:#F9FAFB; margin-bottom:16px;">Human-in-the-Loop Queue</MudText>
+
+@if (!_loaded)
+{
+    <MudProgressLinear Indeterminate="true" Color="Color.Primary" />
+}
+else if (_reviews.Count == 0)
+{
+    <MudAlert Severity="Severity.Success" Style="background:rgba(16,185,129,0.1); color:#10B981; border:1px solid rgba(16,185,129,0.3);">
+        No pending reviews. All agent actions approved.
+    </MudAlert>
+}
+else
+{
+    <MudPaper Elevation="0" Style="border:1px solid #1F2937; border-radius:12px; overflow:hidden;">
+        <MudTable Items="_reviews" Dense="true" Elevation="0" Style="background:transparent !important;">
+            <HeaderContent>
+                <MudTh>Action</MudTh>
+                <MudTh>Trace</MudTh>
+                <MudTh>Created</MudTh>
+                <MudTh>Payload</MudTh>
+                <MudTh>Decision</MudTh>
+            </HeaderContent>
+            <RowTemplate>
+                <MudTd>
+                    <MudText Typo="Typo.body2" Style="color:#E5E7EB; font-weight:600;">@context.Action</MudText>
+                </MudTd>
+                <MudTd>
+                    <code style="font-family:'JetBrains Mono',monospace; font-size:.72rem; color:#6B7280;">
+                        @context.TraceId.ToString()[..8]…
+                    </code>
+                </MudTd>
+                <MudTd>
+                    <MudText Typo="Typo.caption" Style="color:#9CA3AF;">
+                        @context.CreatedAt.ToString("dd MMM HH:mm")
+                    </MudText>
+                </MudTd>
+                <MudTd>
+                    @if (!string.IsNullOrEmpty(context.Payload))
+                    {
+                        <span style="font-family:'JetBrains Mono',monospace; font-size:.7rem; color:#6B7280;">
+                            @context.Payload[..Math.Min(50, context.Payload.Length)]
+                        </span>
+                    }
+                </MudTd>
+                <MudTd>
+                    <div style="display:flex; gap:8px;">
+                        <MudIconButton Icon="@Icons.Material.Filled.CheckCircle"
+                                       Color="Color.Success" Size="Size.Small"
+                                       OnClick="@(() => ApproveAsync(context.Id))"
+                                       title="Approve" />
+                        <MudIconButton Icon="@Icons.Material.Filled.Cancel"
+                                       Color="Color.Error" Size="Size.Small"
+                                       OnClick="@(() => RejectAsync(context.Id))"
+                                       title="Reject" />
+                    </div>
+                </MudTd>
+            </RowTemplate>
+        </MudTable>
+    </MudPaper>
+}
+
+@code {
+    private List<HitlReview> _reviews = [];
+    private bool _loaded;
+
+    private List<BreadcrumbItem> _breadcrumbs =
+    [
+        new("Dashboard", href: "/"),
+        new("HITL Queue", href: null, disabled: true),
+    ];
+
+    protected override async Task OnInitializedAsync()
+    {
+        _reviews = await Svc.GetPendingHitlReviewsAsync();
+        _loaded = true;
+    }
+
+    private async Task ApproveAsync(Guid id)
+    {
+        await Svc.ReviewHitlAsync(id, HitlStatus.Approved, null);
+        _reviews = await Svc.GetPendingHitlReviewsAsync();
+        StateHasChanged();
+    }
+
+    private async Task RejectAsync(Guid id)
+    {
+        await Svc.ReviewHitlAsync(id, HitlStatus.Rejected, null);
+        _reviews = await Svc.GetPendingHitlReviewsAsync();
+        StateHasChanged();
+    }
+}

--- a/src/AgentScope.Web/Services/DashboardService.cs
+++ b/src/AgentScope.Web/Services/DashboardService.cs
@@ -382,6 +382,25 @@ public sealed class DashboardService
         return resp.IsSuccessStatusCode;
     }
 
+    // ── HITL Queue ───────────────────────────────────────────────────────────
+
+    public async Task<List<HitlReview>> GetPendingHitlReviewsAsync(Guid? applicationId = null, CancellationToken ct = default)
+    {
+        await using var db = _factory.CreateDbContext();
+        var query = db.HitlReviews.Where(h => h.Status == HitlStatus.Pending);
+        if (applicationId.HasValue) query = query.Where(h => h.ApplicationId == applicationId.Value);
+        return await query.OrderBy(h => h.CreatedAt).ToListAsync(ct);
+    }
+
+    public async Task ReviewHitlAsync(Guid id, HitlStatus status, string? note, CancellationToken ct = default)
+    {
+        await using var db = _factory.CreateDbContext();
+        var review = await db.HitlReviews.FirstOrDefaultAsync(h => h.Id == id, ct);
+        if (review is null) return;
+        review.Review(status, note, null);
+        await db.SaveChangesAsync(ct);
+    }
+
     private HttpClient GetApiClient() => _httpFactory.CreateClient("AgentScopeApi");
 
     private static PromptSummary ToSummary(Prompt p) =>


### PR DESCRIPTION
## Summary
- `HitlReview` entity (Pending / Approved / Rejected) with action + JSON payload
- `SdkHitlController` at `v1/hitl` (API key auth): create review + poll status
- `HitlManagementController` at `api/v1/hitl` (JWT): list pending + approve/reject
- `HitlQueue.razor` page at `/hitl`: queue table with approve/reject icon buttons
- Nav menu updated with HITL Queue entry

## Test plan
- [ ] Navigate to `/hitl` → queue page loads (empty state shown)
- [ ] POST to `v1/hitl` via API key → review appears in queue
- [ ] Click Approve → review disappears from queue
- [ ] GET `v1/hitl/{id}/status` → returns `Approved`

🤖 Generated with [Claude Code](https://claude.com/claude-code)